### PR TITLE
Send logs

### DIFF
--- a/common/common_util.cc
+++ b/common/common_util.cc
@@ -1,6 +1,4 @@
-
-#include "stdafx.h"
-
+﻿
 #include "bbiconv.cc"
 #include "Buffer.cpp"
 #include "properties.cpp"

--- a/cuteui/base/base_util.cc
+++ b/cuteui/base/base_util.cc
@@ -1,6 +1,4 @@
 
-#include "stdafx.h"
-
 //add _NO_GDIPLUS_
 #ifndef _CRT_RAND_S
 #define _CRT_RAND_S

--- a/cuteui/base/lock_impl.h
+++ b/cuteui/base/lock_impl.h
@@ -9,6 +9,7 @@
 #include "build/build_config.h"
 
 #if defined(OS_WIN)
+#include <WinSock2.h>
 #include <windows.h>
 #elif defined(OS_POSIX)
 #include <pthread.h>

--- a/cuteui/base/logging.cc
+++ b/cuteui/base/logging.cc
@@ -770,7 +770,11 @@ LogMessage::~LogMessage() {
     }
   }
 
-  if (nullptr != logging::g_sentry_client && severity_ == LOG_ERROR) {
+  bool need_send_to_sentry = (severity_ >= LOG_ERROR);
+#ifdef _DEBUG
+  need_send_to_sentry = true;
+#endif
+  if (need_send_to_sentry && nullptr != logging::g_sentry_client) {
     size_t start = str_newline.find(':');
     logging::g_sentry_client->capture_message(std::string("[") +
                                               str_newline.substr(start + 1));

--- a/cuteui/base/logging.cc
+++ b/cuteui/base/logging.cc
@@ -97,8 +97,7 @@ const char* log_severity_name(int severity) {
   return "UNKNOWN";
 }
 // 自行添加的
-void EmptyCb(std::string log, int severity, void* user_data) { return; }
-LoggingSettings::Callback g_callback = EmptyCb;
+LoggingSettings::Callback g_callback = nullptr;
 void* g_user_data = nullptr;
 
 int g_min_log_level = 0;
@@ -381,7 +380,7 @@ LoggingSettings::LoggingSettings()
       delete_old(APPEND_TO_OLD_LOG_FILE) {}
 
 bool BaseInitLoggingImpl(const LoggingSettings& settings) {
-  g_callback = nullptr == settings.callback ? EmptyCb : settings.callback;
+  g_callback = settings.callback;
 #if defined(OS_NACL)
   // Can log only to the system debug log.
   CHECK_EQ(settings.logging_dest & ~LOG_TO_SYSTEM_DEBUG_LOG, 0);
@@ -772,7 +771,7 @@ LogMessage::~LogMessage() {
     }
   }
 
-  g_callback(str_newline, severity_, g_user_data);
+  if (nullptr != g_callback) g_callback(str_newline, severity_, g_user_data);
 
   if (severity_ == LOG_FATAL) {
     // Write the log message to the global activity tracker, if running.

--- a/cuteui/base/logging.cc
+++ b/cuteui/base/logging.cc
@@ -97,7 +97,9 @@ const char* log_severity_name(int severity) {
   return "UNKNOWN";
 }
 // 自行添加的
-std::shared_ptr<nlohmann::crow> g_sentry_client;
+void EmptyCb(std::string log, int severity, void* user_data) { return; }
+LoggingSettings::Callback g_callback = EmptyCb;
+void* g_user_data = nullptr;
 
 int g_min_log_level = 0;
 
@@ -379,7 +381,7 @@ LoggingSettings::LoggingSettings()
       delete_old(APPEND_TO_OLD_LOG_FILE) {}
 
 bool BaseInitLoggingImpl(const LoggingSettings& settings) {
-  g_sentry_client = settings.sentry_client;
+  g_callback = nullptr == settings.callback ? EmptyCb : settings.callback;
 #if defined(OS_NACL)
   // Can log only to the system debug log.
   CHECK_EQ(settings.logging_dest & ~LOG_TO_SYSTEM_DEBUG_LOG, 0);
@@ -770,15 +772,7 @@ LogMessage::~LogMessage() {
     }
   }
 
-  bool need_send_to_sentry = (severity_ >= LOG_ERROR);
-#ifdef _DEBUG
-  need_send_to_sentry = true;
-#endif
-  if (need_send_to_sentry && nullptr != logging::g_sentry_client) {
-    size_t start = str_newline.find(':');
-    logging::g_sentry_client->capture_message(std::string("[") +
-                                              str_newline.substr(start + 1));
-  }
+  g_callback(str_newline, severity_, g_user_data);
 
   if (severity_ == LOG_FATAL) {
     // Write the log message to the global activity tracker, if running.

--- a/cuteui/base/logging.h
+++ b/cuteui/base/logging.h
@@ -14,6 +14,7 @@
 #include <type_traits>
 #include <utility>
 #include <memory>
+#include <functional>
 
 #include "base/base_export.h"
 // #include "base/callback_forward.h"
@@ -23,9 +24,6 @@
 #include "base/string/string_piece_forward.h"
 // #include "base/template_util.h"
 #include "build/build_config.h"
-
-// 修改添加的
-#include "../../../crow/include/crow/crow.hpp"
 
 //
 // Optional message capabilities
@@ -203,7 +201,10 @@ struct BASE_EXPORT LoggingSettings {
   const PathChar* log_file;
   LogLockingState lock_log;
   OldFileDeletionState delete_old;
-  std::shared_ptr<nlohmann::crow> sentry_client;
+  using Callback =
+      std::function<void(std::string log, int severity, void* user_data)>;
+  Callback callback = nullptr;
+  void* user_data = nullptr;
 };
 
 // Define different names for the BaseInitLoggingImpl() function depending on


### PR DESCRIPTION
* Remove `#include "stdafx.h"` in VS2017 project: __missevan_fm_kenerl__.
* Rend all logs under debug. Send logs which severity_ above LOG_ERROR under release.