### PR TITLE
计算崩溃堆栈信息的位置

### DIFF
--- a/cuteui/base/debug/stack_trace_win.cc
+++ b/cuteui/base/debug/stack_trace_win.cc
@@ -195,13 +195,12 @@ class SymbolContext {
       // Output the backtrace line.
       (*os) << "\t";
       if (has_symbol) {
-        (*os) << symbol->Name << "[" << module_name << " 0x"
-              << module_displacement << "+"
-              << sym_displacement << "]";
+        (*os) << symbol->Name << " [" << module_name << " 0x"
+              << module_displacement << "+" << sym_displacement << "]";
       } else {
         // If there is no symbol information, add a spacer.
-        (*os) << "(No symbol)"
-              << "[" << module_name << " 0x" << module_displacement << "]";
+        (*os) << "(No symbol) [" << module_name << " 0x" << module_displacement
+              << "]";
       }
       if (has_line) {
         (*os) << " (" << line.FileName << ":" << line.LineNumber << ")";

--- a/cuteui/base/debug/stack_trace_win.cc
+++ b/cuteui/base/debug/stack_trace_win.cc
@@ -189,17 +189,19 @@ class SymbolContext {
 
       char module_name[MAX_PATH] = {};
       FindModuleName(trace_module[i], module_name, sizeof(module_name));
-      DWORD_PTR pc = frame - reinterpret_cast<DWORD_PTR>(trace_module[i]);
+      DWORD_PTR module_displacement =
+          frame - reinterpret_cast<DWORD_PTR>(trace_module[i]);
 
       // Output the backtrace line.
       (*os) << "\t";
       if (has_symbol) {
-        (*os) << symbol->Name << "[" << module_name << " 0x" << pc << "+"
+        (*os) << symbol->Name << "[" << module_name << " 0x"
+              << module_displacement << "+"
               << sym_displacement << "]";
       } else {
         // If there is no symbol information, add a spacer.
         (*os) << "(No symbol)"
-              << "[" << module_name << " 0x" << pc << "]";
+              << "[" << module_name << " 0x" << module_displacement << "]";
       }
       if (has_line) {
         (*os) << " (" << line.FileName << ":" << line.LineNumber << ")";

--- a/cuteui/base/debug/stack_trace_win.cc
+++ b/cuteui/base/debug/stack_trace_win.cc
@@ -207,30 +207,6 @@ static HMODULE GetModuleFromAddress(LPVOID address)
     return nullptr;
 }
 
-/*
- * FindModuleName
- *      Finds module filename or "unknown"
- */
-static const char* FindModuleName(HMODULE module, char* output, DWORD maxsize) {
-  if (GetModuleFileNameA(module, output, maxsize)) {
-    // Finds the filename part in the output string
-    char* filename = strrchr(output, '\\');
-    if (!filename) filename = strrchr(output, '/');
-
-    // If filename found (i.e. output isn't already a filename but full path),
-    // make output be filename
-    if (filename) {
-      size_t size = strlen(++filename);
-      memmove(output, filename, size);
-      output[size] = 0;
-    }
-  } else {
-    // Unknown module
-    strcpy(output, "unknown");
-  }
-  return output;
-}
-
 bool EnableInProcessStackDumping() {
   // Add stack dumping support on exception on windows. Similar to OS_POSIX
   // signal() handling in process_util_posix.cc.

--- a/cuteui/base/debug/stack_trace_win.cc
+++ b/cuteui/base/debug/stack_trace_win.cc
@@ -184,13 +184,13 @@ class SymbolContext {
       DWORD line_displacement = 0;
       IMAGEHLP_LINE64 line = {};
       line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
-      DWORD_PTR pc =
-          frame - reinterpret_cast<DWORD_PTR>(trace_module[i]);
       BOOL has_line = SymGetLineFromAddr64(GetCurrentProcess(), frame,
                                            &line_displacement, &line);
+
       const int kMaxSize = 256;
       char module_name[kMaxSize] = {};
       FindModuleName(trace_module[i], module_name, kMaxSize);
+      DWORD_PTR pc = frame - reinterpret_cast<DWORD_PTR>(trace_module[i]);
 
       // Output the backtrace line.
       (*os) << "\t";

--- a/cuteui/base/debug/stack_trace_win.cc
+++ b/cuteui/base/debug/stack_trace_win.cc
@@ -196,11 +196,11 @@ class SymbolContext {
       (*os) << "\t";
       if (has_symbol) {
         (*os) << symbol->Name << " [" << module_name << " 0x"
-              << module_displacement << "+" << sym_displacement << "]";
+              << (void*)module_displacement << "+" << sym_displacement << "]";
       } else {
         // If there is no symbol information, add a spacer.
-        (*os) << "(No symbol) [" << module_name << " 0x" << module_displacement
-              << "]";
+        (*os) << "(No symbol) [" << module_name << " 0x"
+              << (void*)module_displacement << "]";
       }
       if (has_line) {
         (*os) << " (" << line.FileName << ":" << line.LineNumber << ")";

--- a/cuteui/base/debug/stack_trace_win.cc
+++ b/cuteui/base/debug/stack_trace_win.cc
@@ -187,7 +187,7 @@ class SymbolContext {
       BOOL has_line = SymGetLineFromAddr64(GetCurrentProcess(), frame,
                                            &line_displacement, &line);
 
-      char module_name[MAX_PATH] = {};
+      char module_name[MAX_PATH];
       FindModuleName(trace_module[i], module_name, sizeof(module_name));
       DWORD_PTR module_displacement =
           frame - reinterpret_cast<DWORD_PTR>(trace_module[i]);

--- a/cuteui/base/debug/stack_trace_win.cc
+++ b/cuteui/base/debug/stack_trace_win.cc
@@ -186,7 +186,7 @@ class SymbolContext {
       line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
       DWORD_PTR pc =
           frame - reinterpret_cast<DWORD_PTR>(trace_module[i]);
-      BOOL has_line = SymGetLineFromAddr64(GetCurrentProcess(), pc,
+      BOOL has_line = SymGetLineFromAddr64(GetCurrentProcess(), frame,
                                            &line_displacement, &line);
       const int kMaxSize = 256;
       char module_name[kMaxSize] = {};

--- a/cuteui/base/file/file.h
+++ b/cuteui/base/file/file.h
@@ -57,6 +57,8 @@ namespace base{
 		HANDLE m_hFile;
 		unsigned long m_mode;
 
+		friend class MiniDump;
+
 		//std::wstring m_path;
 	};
 };

--- a/cuteui/base/file/file.h
+++ b/cuteui/base/file/file.h
@@ -57,8 +57,6 @@ namespace base{
 		HANDLE m_hFile;
 		unsigned long m_mode;
 
-		friend class MiniDump;
-
 		//std::wstring m_path;
 	};
 };


### PR DESCRIPTION
【直播助手崩溃堆栈信息的指针的程序计数器计算好后再写入日志】 https://www.tapd.bilibili.co/35612194/prong/stories/view/1135612194002572502

输出截图：
![image](https://user-images.githubusercontent.com/50010647/147730672-f113b2e0-368a-406d-a49d-790a2ba87bc4.png)
