### PR TITLE
添加 FR_EXPORT 判断

### DIFF
--- a/base/base_export.h
+++ b/base/base_export.h
@@ -1,6 +1,9 @@
-
+#if defined(FR_EXPORT)
 #if defined(WIN32)
 #define BASE_EXPORT __declspec(dllexport)
 #else
-#define BASE_EXPORT __declspec(dllimport)
+#define BASE_EXPORT __attribute__((visibility("default")))
+#endif
+#else
+#define BASE_EXPORT
 #endif


### PR DESCRIPTION
将 BASE_EXPORT 宏定义置空，避免引用 fr 静态库时会导出 fr 函数